### PR TITLE
Update css selectors, remove elements from the DOM with JS

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,25 @@
+
+const selectors = [
+    '#ad_unit',
+    '#main-ad',
+    '#special-upgrade-sidebar',
+    '#board-layout-ad',
+    '#tall-sidebar-ad',
+    '.short-sidebar-ad-component',
+    '.short-sidebar-ad-top',
+    '.short-sidebar-ad-bottom',
+    '.index-content-ad-wrapper',
+    '.upgrade-push-down',
+    '.r2d2-wrapper'
+]
+
+selectors.forEach(s => {
+    const el = document.querySelector(s)
+    if (el) {
+        console.log('removing', s)
+        el.remove()
+    }
+    else {
+        console.log('not found', s)
+    }
+})

--- a/inject.js
+++ b/inject.js
@@ -13,13 +13,4 @@ const selectors = [
     '.r2d2-wrapper'
 ]
 
-selectors.forEach(s => {
-    const el = document.querySelector(s)
-    if (el) {
-        console.log('removing', s)
-        el.remove()
-    }
-    else {
-        console.log('not found', s)
-    }
-})
+document.querySelectorAll(selectors.join(', ')).forEach((el) => el.remove());

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Adblock for Chess.com",
     "description": "Removes ads from Chess.com",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "icons": {
         "16": "img/icon-16x16.png",
         "32": "img/icon-32x32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Adblock for Chess.com",
     "description": "Removes ads from Chess.com",
     "version": "1.0.2",
@@ -16,6 +16,9 @@
             ],
             "css": [
                 "styles.css"
+            ],
+            "js": [
+                "inject.js"
             ]
         }
     ]

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,16 @@
+iframe,
+#ad_unit,
 #main-ad,
 #special-upgrade-sidebar,
 #board-layout-ad,
 #tall-sidebar-ad,
 .short-sidebar-ad-component,
+.short-sidebar-ad-top,
 .index-content-ad-wrapper,
 .upgrade-push-down,
 .r2d2-wrapper {
     display: none !important;
+    height: 0 !important;
+    overflow: hidden !important;
 }
+


### PR DESCRIPTION
Hi there, I just updated the adblocker by using js to remove Ads elements fro the DOM on every page of the website.
So now you'll not have ads on the home page either.
They use to prevent your CSS tricks by using inline style to enforce display block :) 